### PR TITLE
Clean up Boost files after build

### DIFF
--- a/com.chatterino.chatterino.yml
+++ b/com.chatterino.chatterino.yml
@@ -13,6 +13,9 @@ finish-args:
   - --device=dri
   - --env=QT_QPA_PLATFORM=xcb
   - --talk-name=org.freedesktop.Flatpak
+cleanup:
+  - /include
+  - /lib
 modules:
   - name: boost
     buildsystem: simple


### PR DESCRIPTION
(see: https://github.com/Chatterino/chatterino2/issues/3706)

The current Flatpak distribution retains the Boost source files and static libs, these should be removed. 
