### PR TITLE
Update to Chatterino v2.4.0

### DIFF
--- a/com.chatterino.chatterino.yml
+++ b/com.chatterino.chatterino.yml
@@ -60,8 +60,8 @@ modules:
       - "-DUSE_SYSTEM_QTKEYCHAIN=ON"
     sources:
       - type: git
-        url: https://github.com/chatterino/chatterino2
-        commit: dbaab6cc20603b0fe48a6a82a6bf316a08d51ccc
+        url: https://github.com/Chatterino/chatterino2.git
+        commit: 2ba4da02aecf937c740ef9b0a9f7bd7b8c3ef256
     post-install:
       - install -Dm755 ./resources/icon.png /app/share/icons/hicolor/256x256/apps/chatterino.png
       - install -Dm755 ./resources/com.chatterino.chatterino.appdata.xml /app/share/metainfo/com.chatterino.chatterino.appdata.xml


### PR DESCRIPTION
The libsecret/qtkeychain build processes have been taken from the `beta` branch

This will include some commits that are not part of the actual v2.4.0 release, but it's required to fix some
qtkeychain-related issues.

If necessary, the changes could be applied as a patch but the difference between this commit hash and the v2.4.0 release are not big 

Raw commits: https://github.com/Chatterino/chatterino2/compare/v2.4.0..2ba4da02aecf937c740ef9b0a9f7bd7b8c3ef256

<details>
<summary>Changelog entries from v2.4.0 to the commit used in this PR</summary>
- Minor: Added ability to negate search options by prefixing it with an exclamation mark (e.g. `!badge:mod` to search for messages where the author does not have the moderator badge). (#4207)
- Minor: Search window input will automatically use currently selected text if present. (#4178)
- Minor: Cleared up highlight sound settings (#4194)
- Minor: Tables in settings window will now scroll to newly added rows. (#4216)
- Minor: Added link to streamlink docs for easier user setup. (#4217)
- Minor: Added setting to turn off rendering of reply context. (#4224)
- Bugfix: Fixed highlight sounds not reloading on change properly. (#4194)
- Bugfix: Fixed CTRL + C not working in reply thread popups. (#4209)
- Bugfix: Fixed message input showing as red after removing a message that was more than 500 characters. (#4204)
- Bugfix: Fixed unnecessary saving of windows layout. (#4201)
- Bugfix: Fixed Reply window missing selection clear behaviour between chat and input box. (#4218)
- Bugfix: Fixed crash that could occur when changing Tab layout and utilizing multiple windows. (#4248)
- Dev: Ignore `WM_SHOWWINDOW` hide events, causing fewer attempted rescales. (#4198)

</details>

Fixes #6 