### PR TITLE
Update runtime to 5.15-22.08

### DIFF
--- a/com.chatterino.chatterino.yml
+++ b/com.chatterino.chatterino.yml
@@ -1,6 +1,6 @@
 app-id: com.chatterino.chatterino
 runtime: org.kde.Platform
-runtime-version: '5.15-21.08'
+runtime-version: '5.15-22.08'
 sdk: org.kde.Sdk
 command: chatterino
 finish-args:


### PR DESCRIPTION
5.15-21.08 is end of life and 5.15-22.08 seems to work just fine without any changes.