### PR TITLE
update deprecated boost url

### DIFF
--- a/com.chatterino.chatterino.yml
+++ b/com.chatterino.chatterino.yml
@@ -22,7 +22,7 @@ modules:
         -fstack-protector-strong -D_FORTIFY_SOURCE=2' --layout=system
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.85.0/source/boost_1_85_0.tar.gz
+        url: https://archives.boost.io/release/1.85.0/source/boost_1_85_0.tar.gz
         sha256: be0d91732d5b0cc6fbb275c7939974457e79b54d6f07ce2e3dfdd68bef883b0b
     cleanup:
       - /lib


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
