### PR TITLE
Drop libsecret module

### DIFF
--- a/com.chatterino.chatterino.yml
+++ b/com.chatterino.chatterino.yml
@@ -26,22 +26,7 @@ modules:
         sha256: be0d91732d5b0cc6fbb275c7939974457e79b54d6f07ce2e3dfdd68bef883b0b
     cleanup:
       - /lib
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      - -Dmanpage=false
-      - -Dvapi=false
-      - -Dgtk_doc=false
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/gir-1.0
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.4.tar.xz
-        sha256: 163d08d783be6d4ab9a979ceb5a4fecbc1d9660d3c34168c581301cd53912b20
+
   - name: qtkeychain
     buildsystem: cmake-ninja
     sources:
@@ -53,6 +38,7 @@ modules:
       - -DLIB_INSTALL_DIR=/app/lib
       - -DBUILD_TRANSLATIONS=NO
       - -DBUILD_WITH_QT6=ON
+
   - name: chatterino
     buildsystem: cmake
     config-opts:


### PR DESCRIPTION
reedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides libsecret; therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes: https://github.com/flathub/com.chatterino.chatterino/issues/803